### PR TITLE
feat: 공공데이터 DB에 저장하기

### DIFF
--- a/src/main/java/com/goo/bikerelocationproject/controller/StationOpenApiController.java
+++ b/src/main/java/com/goo/bikerelocationproject/controller/StationOpenApiController.java
@@ -16,7 +16,7 @@ public class StationOpenApiController {
   private final StationOpenApiServiceImpl stationApiService;
 
   @PostMapping("/open-api")
-  public ResponseEntity<ParsingResultDto> getOpenApiData() {
+  public ResponseEntity<ParsingResultDto> saveOpenApiData() {
 
     ParsingResultDto parsingResult = stationApiService.getOpenApiData();
 

--- a/src/main/java/com/goo/bikerelocationproject/controller/StationOpenApiController.java
+++ b/src/main/java/com/goo/bikerelocationproject/controller/StationOpenApiController.java
@@ -1,0 +1,26 @@
+package com.goo.bikerelocationproject.controller;
+
+import com.goo.bikerelocationproject.data.dto.ParsingResultDto;
+import com.goo.bikerelocationproject.service.impl.StationOpenApiServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class StationOpenApiController {
+
+  private final StationOpenApiServiceImpl stationApiService;
+
+  @PostMapping("/open-api")
+  public ResponseEntity<ParsingResultDto> getOpenApiData() {
+
+    ParsingResultDto parsingResult = stationApiService.getOpenApiData();
+
+    return ResponseEntity.ok(parsingResult);
+  }
+
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/BikeListApiDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/BikeListApiDto.java
@@ -1,0 +1,32 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import com.goo.bikerelocationproject.data.entity.Station;
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class BikeListApiDto {
+
+  // url : https://data.seoul.go.kr/dataList/OA-15493/A/1/datasetView.do
+
+  private String stationId;
+
+  @SerializedName("rackTotCnt")
+  private String rackTotalCount;
+
+  private String stationName;
+
+  public static Station toEntity(BikeListApiDto bikeListApiDto) {
+    return Station.builder()
+        .id(Long.valueOf(bikeListApiDto.getStationId().substring(3)))
+        .rackTotalCount(Integer.parseInt(bikeListApiDto.getRackTotalCount()))
+        .stationName(bikeListApiDto.getStationName())
+        .build();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/BikeStationMasterApiDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/BikeStationMasterApiDto.java
@@ -1,0 +1,25 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class BikeStationMasterApiDto {
+
+  // url : https://data.seoul.go.kr/dataList/OA-21235/S/1/datasetView.do
+
+  @SerializedName("LENDPLACE_ID")
+  private String stationId;
+
+  @SerializedName("STATN_ADDR1")
+  private String address1;
+
+  @SerializedName("STATN_ADDR2")
+  private String address2;
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/OpenApiErrorResponse.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/OpenApiErrorResponse.java
@@ -1,0 +1,18 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OpenApiErrorResponse {
+
+  private String errorCode;
+  private String errorMessage;
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/ParsingResultDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/ParsingResultDto.java
@@ -1,7 +1,5 @@
 package com.goo.bikerelocationproject.data.dto;
 
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -11,8 +9,6 @@ import lombok.ToString;
 @ToString
 public class ParsingResultDto {
 
-  int bikeListTotalCount;
-  int savedBikeStationMasterTotalCount;
-  List<String> code = new ArrayList<>();
-  List<String> message = new ArrayList<>();
+  private int bikeListTotalCount;
+  private int savedBikeStationMasterTotalCount;
 }

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/ParsingResultDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/ParsingResultDto.java
@@ -1,0 +1,18 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ParsingResultDto {
+
+  int bikeListTotalCount;
+  int savedBikeStationMasterTotalCount;
+  List<String> code = new ArrayList<>();
+  List<String> message = new ArrayList<>();
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/StationErrorResponse.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/StationErrorResponse.java
@@ -1,0 +1,19 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import com.goo.bikerelocationproject.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class StationErrorResponse {
+
+  private ErrorCode errorCode;
+  private String errorMessage;
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/StatusApiDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/StatusApiDto.java
@@ -1,0 +1,18 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class StatusApiDto {
+
+  @SerializedName("CODE")
+  private String code;
+
+  @SerializedName("MESSAGE")
+  private String message;
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/entity/Station.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/entity/Station.java
@@ -1,0 +1,27 @@
+package com.goo.bikerelocationproject.data.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Station {
+
+  @Id
+  private Long id;
+  private int rackTotalCount;
+  private String stationName;
+  private String address1;
+  private String address2;
+}

--- a/src/main/java/com/goo/bikerelocationproject/exception/OpenApiException.java
+++ b/src/main/java/com/goo/bikerelocationproject/exception/OpenApiException.java
@@ -1,0 +1,27 @@
+package com.goo.bikerelocationproject.exception;
+
+import com.goo.bikerelocationproject.data.dto.StatusApiDto;
+import com.goo.bikerelocationproject.type.OpenApiDataType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
+public class OpenApiException extends RuntimeException {
+
+  private OpenApiDataType openApiDataType;
+  private String code;
+  private String message;
+
+  public OpenApiException(OpenApiDataType openApiDataType, StatusApiDto statusApiDto) {
+    this.openApiDataType = openApiDataType;
+    this.code = statusApiDto.getCode();
+    this.message = statusApiDto.getMessage();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/exception/StationException.java
+++ b/src/main/java/com/goo/bikerelocationproject/exception/StationException.java
@@ -1,0 +1,24 @@
+package com.goo.bikerelocationproject.exception;
+
+import com.goo.bikerelocationproject.type.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@Builder
+public class StationException extends RuntimeException {
+
+  private ErrorCode code;
+  private String message;
+
+  public StationException(ErrorCode errorCode) {
+    this.code = errorCode;
+    this.message = errorCode.getDescription();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/goo/bikerelocationproject/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.goo.bikerelocationproject.exception.handler;
+
+import com.goo.bikerelocationproject.data.dto.OpenApiErrorResponse;
+import com.goo.bikerelocationproject.data.dto.StationErrorResponse;
+import com.goo.bikerelocationproject.exception.OpenApiException;
+import com.goo.bikerelocationproject.exception.StationException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+  private final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+  @ExceptionHandler(OpenApiException.class)
+  public OpenApiErrorResponse handleOpenApiException(OpenApiException e) {
+    LOGGER.error("[open-api error]: " + e);
+
+    return new OpenApiErrorResponse(e.getCode(), e.getMessage());
+  }
+
+  @ExceptionHandler(StationException.class)
+  public StationErrorResponse handleStationException(StationException e) {
+    LOGGER.error("[station error]: " + e);
+
+    return new StationErrorResponse(e.getCode(), e.getMessage());
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/repository/StationRepo.java
+++ b/src/main/java/com/goo/bikerelocationproject/repository/StationRepo.java
@@ -1,0 +1,7 @@
+package com.goo.bikerelocationproject.repository;
+
+import com.goo.bikerelocationproject.data.entity.Station;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StationRepo extends JpaRepository<Station, Long> {
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/StationOpenApiService.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/StationOpenApiService.java
@@ -5,6 +5,7 @@ import com.goo.bikerelocationproject.data.dto.ParsingResultDto;
 public interface StationOpenApiService {
 
   ParsingResultDto getOpenApiData();
-  void getBikeListData(ParsingResultDto parsingResultDto);
-  void getBikeStationMasterData(ParsingResultDto parsingResultDto);
+  int saveBikeListData();
+  int saveBikeStationMasterData();
+  String getJsonString(String a, int b, int c);
 }

--- a/src/main/java/com/goo/bikerelocationproject/service/StationOpenApiService.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/StationOpenApiService.java
@@ -1,0 +1,10 @@
+package com.goo.bikerelocationproject.service;
+
+import com.goo.bikerelocationproject.data.dto.ParsingResultDto;
+
+public interface StationOpenApiService {
+
+  ParsingResultDto getOpenApiData();
+  void getBikeListData(ParsingResultDto parsingResultDto);
+  void getBikeStationMasterData(ParsingResultDto parsingResultDto);
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/impl/StationOpenApiServiceImpl.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/impl/StationOpenApiServiceImpl.java
@@ -1,0 +1,182 @@
+package com.goo.bikerelocationproject.service.impl;
+
+import com.goo.bikerelocationproject.data.dto.BikeListApiDto;
+import com.goo.bikerelocationproject.data.dto.BikeStationMasterApiDto;
+import com.goo.bikerelocationproject.data.dto.ParsingResultDto;
+import com.goo.bikerelocationproject.data.dto.StatusApiDto;
+import com.goo.bikerelocationproject.data.entity.Station;
+import com.goo.bikerelocationproject.repository.StationRepo;
+import com.goo.bikerelocationproject.service.StationOpenApiService;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StationOpenApiServiceImpl implements StationOpenApiService {
+
+  @Value("${bike-list-api-key}")
+  private String apiKey;
+
+  private final StationRepo stationRepo;
+
+  HttpURLConnection con = null;
+  StringBuilder sb = null;
+  Gson gson = null;
+  URL url = null;
+
+  @Override
+  public ParsingResultDto getOpenApiData() {
+
+    ParsingResultDto result = new ParsingResultDto();
+
+    getBikeListData(result);
+    getBikeStationMasterData(result);
+
+    return result;
+  }
+
+  @Override
+  public void getBikeListData(ParsingResultDto result) {
+    int pageNum = 0;
+    boolean isRemain = true;
+
+    List<Station> stations = new ArrayList<>();
+    while (isRemain) {
+      int start = 1000 * pageNum++ + 1;
+      int end = 1000 * pageNum;
+
+      String baseUrl = getBaseUrl("bikeList", start, end);
+      sb = new StringBuilder();
+      try {
+        url = new URL(baseUrl);
+        con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("GET");
+        con.setRequestProperty("Content-type", "application/json");
+        con.setDoOutput(true);
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8"));
+        while (br.ready()) {
+          sb.append(br.readLine());
+        }
+        con.disconnect();
+
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      gson = new Gson();
+
+      JsonObject objData = (JsonObject) new JsonParser().parse(sb.toString());
+      JsonObject data = (JsonObject) objData.get("rentBikeStatus");
+      JsonObject statusInfo = (JsonObject) data.get("RESULT");
+      JsonArray jsonArray = (JsonArray) data.get("row");
+
+      int listTotalCount = Integer.parseInt(String.valueOf(data.get("list_total_count")));
+      if (listTotalCount < 1000) {
+        isRemain = false;
+      }
+
+      StatusApiDto statusApiDto = gson.fromJson(statusInfo, StatusApiDto.class);
+      result.setBikeListTotalCount(result.getBikeListTotalCount() + listTotalCount);
+      result.getCode().add("[bikeList]: " +  statusApiDto.getCode());
+      result.getMessage().add("[bikeList]: " + statusApiDto.getMessage());
+
+      for (int i = 0; i < jsonArray.size(); i++) {
+        BikeListApiDto bikeListApiDto = gson.fromJson(jsonArray.get(i), BikeListApiDto.class);
+        stations.add(BikeListApiDto.toEntity(bikeListApiDto));
+      }
+    }
+    stationRepo.saveAll(stations);
+  }
+
+  @Override
+  public void getBikeStationMasterData(ParsingResultDto result) {
+    int pageNum = 0;
+    boolean isRemain = true;
+
+    while (isRemain) {
+      int start = 1000 * pageNum++ + 1;
+      int end = 1000 * pageNum;
+
+      String baseUrl = getBaseUrl("bikeStationMaster", start, end);
+      sb = new StringBuilder();
+      try {
+        url = new URL(baseUrl);
+        con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("GET");
+        con.setRequestProperty("Content-type", "application/json");
+        con.setDoOutput(true);
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), "UTF-8"));
+        while (br.ready()) {
+          sb.append(br.readLine());
+        }
+        con.disconnect();
+
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      gson = new Gson();
+
+      JsonObject objData = (JsonObject) new JsonParser().parse(sb.toString());
+      JsonObject data = (JsonObject) objData.get("bikeStationMaster");
+      JsonObject statusInfo = (JsonObject) data.get("RESULT");
+      JsonArray jsonArray = (JsonArray) data.get("row");
+
+      int listTotalCount = Integer.parseInt(String.valueOf(data.get("list_total_count")));
+      if (listTotalCount < end) {
+        isRemain = false;
+      }
+
+      StatusApiDto statusApiDto = gson.fromJson(statusInfo, StatusApiDto.class);
+      result.getCode().add("[bikeStationMaster]: " + statusApiDto.getCode());
+      result.getMessage().add("[bikeStationMaster]: " + statusApiDto.getMessage());
+
+      int savedDataCount = 0;
+      for (int i = 0; i < jsonArray.size(); i++) {
+        BikeStationMasterApiDto bikeStationMasterApiDto =
+            gson.fromJson(jsonArray.get(i), BikeStationMasterApiDto.class);
+
+        Optional<Station> station =
+            stationRepo.findById(
+                Long.valueOf(bikeStationMasterApiDto.getStationId().substring(3)));
+
+        if (station.isPresent()) {
+          Station selectedStation = station.get();
+          selectedStation.setAddress1(bikeStationMasterApiDto.getAddress1());
+          selectedStation.setAddress2(bikeStationMasterApiDto.getAddress2());
+          stationRepo.save(selectedStation);
+          savedDataCount++;
+        }
+      }
+      result.setSavedBikeStationMasterTotalCount(result.getSavedBikeStationMasterTotalCount() + savedDataCount);
+    }
+  }
+
+  String getBaseUrl(String dataType, int start, int end) {
+    StringBuilder baseUrl = new StringBuilder();
+
+    baseUrl.append("http://openapi.seoul.go.kr:8088/");
+    baseUrl.append(apiKey);
+    baseUrl.append("/json/");
+    baseUrl.append(dataType);
+    baseUrl.append("/");
+    baseUrl.append(start);
+    baseUrl.append("/");
+    baseUrl.append(end);
+    baseUrl.append("/");
+
+    return baseUrl.toString();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/type/ErrorCode.java
+++ b/src/main/java/com/goo/bikerelocationproject/type/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.goo.bikerelocationproject.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+  OPEN_API_ERROR("open-api 데이터를 가져오는 것에 실패했습니다.");
+
+  private final String description;
+}

--- a/src/main/java/com/goo/bikerelocationproject/type/OpenApiDataType.java
+++ b/src/main/java/com/goo/bikerelocationproject/type/OpenApiDataType.java
@@ -1,0 +1,14 @@
+package com.goo.bikerelocationproject.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OpenApiDataType {
+
+  BIKE_LIST("bikeLis"),
+  BIKE_STATION_MASTER("bikeStationMaster");
+
+  private final String data;
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**
// Gson 을 이용하여 2개의 open api 데이터를 하나의 DB 테이블에 저장했습니다. (기본정보 / 주소정보)

- 데이터 저장 컨트롤러 prifix 변경 (get** -> save**)
- dto 필드에 private 추가
- HttpUrlConnection -> RestTemplate 변경
- list 에 결과메시지 add하는 형식 -> api 파싱 결과 예외처리로 변경
- api 데이터 타입 문자열(api url 의 pathVariable 문자열) -> enum 타입으로 변경

### 테스트

- [ ] 테스트 코드
- [ ] API 테스트 

### 궁금증
2개의 api 를 하나의 테이블에 저장하기 vs 각각의 테이블에 저장 후 join 으로 조회하기
(스케쥴링은 하루에 한 번으로 설정 예정)

> 전자의 경우
>
> 단점 : 첫번째 api 데이터를 저장후 두번째 api 저장할 때, 매번 findById() 로 조회해서 업데이트 해야해서 저장속도가 느리다.
>
> 장점 : 한번 테이블이 업데이트 되면 한 테이블에 두개의 api에서 파싱한 데이터가 모두 들어있으므로 조회 시 추가적인 쿼리 실행이 필요없다.

> 후자의 경우
>
> 단점 : 대여소 정보를 조회할 때 매번 두 테이블의 id가 일치하는 지 확인 후 join 으로 출력해야 해서 조회속도가 느리다.
>
> 장점 : 두개의 api를 각각의 테이블에 저장하기 때문에 상대적으로 저장속도가 빠르다.

- 각각의 장단점과 현재 프로젝트 특성을 고려했을 때 전자를 선택했습니다. 데이터가 2000-3000개 정도 되고, api를 파싱하여 db에 저장하는 것은 하루에 한번 실행되고, 데여소 정보를 출력하는 건 하루에 수십건 이상이어서 전자를 선택했습니다!
혹시 이 외에 도입하면 좋은 기술이나, 더 좋은 방법을 추천해주시면 감사드리겠습니다. 피드백 정말 감사합니다!!