### PR TITLE
feat: 대여소 리스트/상세정보 출력

### DIFF
--- a/src/main/java/com/goo/bikerelocationproject/config/RedisConfig.java
+++ b/src/main/java/com/goo/bikerelocationproject/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -29,5 +30,10 @@ public class RedisConfig {
     redisTemplate.setEnableTransactionSupport(true);
     redisTemplate.setDefaultSerializer(new StringRedisSerializer());
     return redisTemplate;
+  }
+
+  @Bean
+  public ZSetOperations<?, ?> zSetOperations() {
+    return this.redisTemplate().opsForZSet();
   }
 }

--- a/src/main/java/com/goo/bikerelocationproject/controller/StationController.java
+++ b/src/main/java/com/goo/bikerelocationproject/controller/StationController.java
@@ -1,0 +1,31 @@
+package com.goo.bikerelocationproject.controller;
+
+import com.goo.bikerelocationproject.data.dto.StationInfoDto;
+import com.goo.bikerelocationproject.service.impl.StationServiceImpl;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/st")
+public class StationController {
+
+  private final StationServiceImpl stationService;
+
+  @GetMapping("/list")
+  public ResponseEntity<List<StationInfoDto>> getList(Pageable pageable) {
+
+    return ResponseEntity.ok(stationService.getAllStation(pageable));
+  }
+
+  @GetMapping("/detail")
+  public ResponseEntity<StationInfoDto> getDetail(Long stationId) {
+
+    return ResponseEntity.ok(stationService.getDetails(stationId));
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/controller/StationController.java
+++ b/src/main/java/com/goo/bikerelocationproject/controller/StationController.java
@@ -7,12 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/st")
+@RequestMapping("/api/station")
 public class StationController {
 
   private final StationServiceImpl stationService;
@@ -23,8 +24,9 @@ public class StationController {
     return ResponseEntity.ok(stationService.getAllStation(pageable));
   }
 
-  @GetMapping("/detail")
-  public ResponseEntity<StationInfoDto> getDetail(Long stationId) {
+  @GetMapping("/{station-id}")
+  public ResponseEntity<StationInfoDto> getDetail(
+      @PathVariable(name = "station-id") Long stationId) {
 
     return ResponseEntity.ok(stationService.getDetails(stationId));
   }

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/StationInfoDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/StationInfoDto.java
@@ -1,0 +1,34 @@
+package com.goo.bikerelocationproject.data.dto;
+
+import com.goo.bikerelocationproject.data.entity.Station;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class StationInfoDto {
+
+  private Long id;
+  private String stationName;
+  private String address1;
+  private String address2;
+  private int rackTotalCount;
+  private int parkingBikeTotalCount;
+  private double bikeParkingRate;
+
+  public static StationInfoDto fromEntity(Station station, double bikeParkingRate) {
+    return StationInfoDto.builder()
+        .id(station.getId())
+        .stationName(station.getStationName())
+        .address1(station.getAddress1())
+        .address2(station.getAddress2())
+        .rackTotalCount(station.getRackTotalCount())
+        .parkingBikeTotalCount((int) (bikeParkingRate * station.getRackTotalCount() / 100))
+        .bikeParkingRate(bikeParkingRate)
+        .build();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/StationService.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/StationService.java
@@ -1,0 +1,12 @@
+package com.goo.bikerelocationproject.service;
+
+import com.goo.bikerelocationproject.data.dto.StationInfoDto;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+
+public interface StationService {
+
+  List<StationInfoDto> getAllStation(Pageable pageable);
+
+  StationInfoDto getDetails(Long stationId);
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/impl/StationOpenApiServiceImpl.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/impl/StationOpenApiServiceImpl.java
@@ -26,8 +26,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
@@ -40,6 +38,7 @@ public class StationOpenApiServiceImpl implements StationOpenApiService {
 
   private final StationRepo stationRepo;
   private final RedisTemplate<String, String> redisTemplate;
+  private final ZSetOperations<String, String> zSetOperations;
   private final WebClient webClient;
 
   @Override
@@ -152,7 +151,6 @@ public class StationOpenApiServiceImpl implements StationOpenApiService {
     int pageNum = 0;
     boolean isRemain = true;
 
-    ZSetOperations<String, String> operations = redisTemplate.opsForZSet();
     Set<TypedTuple<String>> set = new HashSet<>();
     BikeListDto bikeListDto = null;
     ResultDto errorResult = null;
@@ -168,7 +166,8 @@ public class StationOpenApiServiceImpl implements StationOpenApiService {
           errorResult = bikeListDto.getRentBikeStatus().getResult();
         }
 
-        int listTotalCount = Objects.requireNonNull(bikeListDto.getRentBikeStatus()).getListTotalCount();
+        int listTotalCount = Objects.requireNonNull(bikeListDto.getRentBikeStatus())
+            .getListTotalCount();
         if (listTotalCount < 1000) {
           isRemain = false;
         }
@@ -182,7 +181,7 @@ public class StationOpenApiServiceImpl implements StationOpenApiService {
 
       throwException2(errorResult, BIKE_LIST_REDIS);
     }
-    operations.add(REDIS_STATION.getKey(), set);
+    zSetOperations.add(REDIS_STATION.getKey(), set);
     redisTemplate.expire(REDIS_STATION.getKey(), Duration.ofMinutes(5));
   }
 

--- a/src/main/java/com/goo/bikerelocationproject/service/impl/StationServiceImpl.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/impl/StationServiceImpl.java
@@ -1,0 +1,69 @@
+package com.goo.bikerelocationproject.service.impl;
+
+import static com.goo.bikerelocationproject.type.ErrorCode.REDIS_NULL;
+import static com.goo.bikerelocationproject.type.RedisKey.REDIS_STATION;
+
+import com.goo.bikerelocationproject.data.dto.StationInfoDto;
+import com.goo.bikerelocationproject.data.entity.Station;
+import com.goo.bikerelocationproject.exception.StationException;
+import com.goo.bikerelocationproject.repository.StationRepo;
+import com.goo.bikerelocationproject.service.StationService;
+import com.goo.bikerelocationproject.type.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StationServiceImpl implements StationService {
+
+  private final StationRepo stationRepo;
+  private final ZSetOperations<String, String> zSetOperations;
+
+  @Override
+  public List<StationInfoDto> getAllStation(Pageable pageable) {
+
+    Set<TypedTuple<String>> selectedRedisDataSet = getReverseSortedRedis(pageable);
+
+    List<StationInfoDto> stationInfoDtoList = new ArrayList<>();
+
+    for (TypedTuple<String> set : selectedRedisDataSet) {
+      Station station = stationRepo.findById(Long.parseLong(set.getValue()))
+          .orElseThrow(() -> new StationException(REDIS_NULL));
+      stationInfoDtoList.add(StationInfoDto.fromEntity(station, set.getScore()));
+    }
+
+    return stationInfoDtoList;
+  }
+
+  @Override
+  public StationInfoDto getDetails(Long stationId) {
+
+    Station station = stationRepo.findById(stationId)
+        .orElseThrow(() -> new StationException(ErrorCode.NOT_FOUND_STATION));
+
+    double bikeParkingRate = zSetOperations.score(REDIS_STATION.getKey(),
+        String.valueOf(stationId));
+
+    return StationInfoDto.fromEntity(station, bikeParkingRate);
+  }
+
+  Set<TypedTuple<String>> getReverseSortedRedis(Pageable pageable) {
+
+    Set<TypedTuple<String>> set = zSetOperations.reverseRangeByScoreWithScores(
+        REDIS_STATION.getKey(), 100, Double.MAX_VALUE, pageable.getPageNumber(),
+        pageable.getPageSize());
+
+    if (set == null || set.size() == 0) {
+      throw new StationException(REDIS_NULL);
+    }
+
+    return set;
+  }
+
+}

--- a/src/main/java/com/goo/bikerelocationproject/type/ErrorCode.java
+++ b/src/main/java/com/goo/bikerelocationproject/type/ErrorCode.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-  OPEN_API_ERROR("open-api: 데이터 저장에 실패했습니다.");
+  OPEN_API_ERROR("open-api: 데이터 저장에 실패했습니다."),
+  REDIS_NULL("redis 에서 값을 불러오지 못했습니다."),
+  NOT_FOUND_STATION("대여소 정보가 존재하지 않습니다.");
 
   private final String description;
 }

--- a/src/test/http/httpTest.http
+++ b/src/test/http/httpTest.http
@@ -5,9 +5,9 @@ POST http://localhost:8080/api/open-api-station
 POST http://localhost:8080/api/open-api-parking
 
 ### StationController - getList(pageable)
-GET http://localhost:8080/api/st/list?size=10&page=0
+GET http://localhost:8080/api/station/list?size=10&page=0
 Content-Type: application/json
 
 ### StationController - getDetails(stationId)
-GET http://localhost:8080/api/st/detail?stationId=1730
+GET http://localhost:8080/api/station/3277
 Content-Type: application/json

--- a/src/test/http/httpTest.http
+++ b/src/test/http/httpTest.http
@@ -3,3 +3,11 @@ POST http://localhost:8080/api/open-api-station
 
 ### StationOpenApiController - getOpenApiRedisData()
 POST http://localhost:8080/api/open-api-parking
+
+### StationController - getList(pageable)
+GET http://localhost:8080/api/st/list?size=10&page=0
+Content-Type: application/json
+
+### StationController - getDetails(stationId)
+GET http://localhost:8080/api/st/detail?stationId=1730
+Content-Type: application/json

--- a/src/test/java/com/goo/bikerelocationproject/repository/StationRepoTest.java
+++ b/src/test/java/com/goo/bikerelocationproject/repository/StationRepoTest.java
@@ -1,0 +1,113 @@
+package com.goo.bikerelocationproject.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.goo.bikerelocationproject.data.dto.StationInfoDto;
+import com.goo.bikerelocationproject.data.entity.Station;
+import com.goo.bikerelocationproject.type.RedisKey;
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+
+@SpringBootTest
+@Transactional
+class StationRepoTest {
+
+  @Autowired
+  private StationRepo stationRepo;
+
+  @Autowired
+  private RedisTemplate<String, String> redisTemplate;
+
+
+  @Test
+  void getAllStationWithPaging() {
+    // given
+    ZSetOperations<String, String> zSetOperations = redisTemplate.opsForZSet();
+    saveExampleRedisSet(zSetOperations, getExampleStationDataSet());
+
+    stationRepo.save(getExampleStationEntity1());
+    stationRepo.save(getExampleStationEntity2());
+
+    // when
+    Set<TypedTuple<String>> selected = zSetOperations.reverseRangeByScoreWithScores(
+        RedisKey.REDIS_STATION.getKey(), 100, Double.MAX_VALUE, 0, 2);
+
+    System.out.println(selected.size());
+    List<StationInfoDto> stationInfoDtoList = new ArrayList<>();
+
+    Objects.requireNonNull(selected).forEach(m -> {
+      Optional<Station> station = stationRepo.findById(Long.parseLong(
+          Objects.requireNonNull(m.getValue())));
+
+      if (station.isPresent()) {
+        stationInfoDtoList.add(StationInfoDto.fromEntity(station.get(), m.getScore()));
+      }
+    });
+
+    // then
+    assertEquals(2, stationInfoDtoList.size());
+    assertEquals(2, stationInfoDtoList.get(0).getId());
+    assertEquals(10, stationInfoDtoList.get(0).getRackTotalCount());
+    assertEquals(27, stationInfoDtoList.get(0).getParkingBikeTotalCount());
+    assertEquals(270.0, stationInfoDtoList.get(0).getBikeParkingRate());
+  }
+
+  @Test
+  void getDetail() {
+    // given
+    ZSetOperations<String, String> operations = redisTemplate.opsForZSet();
+    Set<TypedTuple<String>> set = getExampleStationDataSet();
+    saveExampleRedisSet(operations, set);
+
+    Station station = stationRepo.save(getExampleStationEntity1());
+
+    // when
+    double score = operations.score(RedisKey.REDIS_STATION.getKey(),
+        String.valueOf(station.getId()));
+
+    // then
+    assertEquals(score, 220.0);
+  }
+
+  Set<TypedTuple<String>> getExampleStationDataSet() {
+    Set<TypedTuple<String>> set = new HashSet<>();
+
+    set.add(TypedTuple.of("1", 220.0));
+    set.add(TypedTuple.of("2", 270.0));
+
+    return set;
+  }
+
+  void saveExampleRedisSet(ZSetOperations<String, String> operations, Set<TypedTuple<String>> set) {
+    operations.add(RedisKey.REDIS_STATION.getKey(), set);
+    redisTemplate.expire(RedisKey.REDIS_STATION.getKey(), Duration.ofSeconds(1));
+  }
+
+  Station getExampleStationEntity1() {
+    return Station.builder()
+        .id(1L)
+        .stationName("3720. 우이천 창번교")
+        .rackTotalCount(5)
+        .build();
+  }
+
+  Station getExampleStationEntity2() {
+    return Station.builder()
+        .id(2L)
+        .stationName("3753. 공항중학교 버스정류장")
+        .rackTotalCount(10)
+        .build();
+  }
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**
- 대여소 전체 리스트 페이징 출력 (자전거 주차율 desc)
- 대여소 상세 정보 출력 (매개변수 : 대여소 아이디)
- 레디스 ZSetOperation 생성 빈 등록 (중복코드 이슈)

### 테스트

- [x] 테스트 코드
- [x] API 테스트 