### PR TITLE
feat: jwt + security 인증인가 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out/
 ### Api Key ###
 /src/main/resources/application.yml
 /src/main/resources/application-api-key.yml
+/src/main/resources/application-jwt-key.yml
+/src/main/resources/application-oauth.yml

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    // implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
@@ -38,6 +38,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     // web client
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    // google social login
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/goo/bikerelocationproject/BikeRelocationProjectApplication.java
+++ b/src/main/java/com/goo/bikerelocationproject/BikeRelocationProjectApplication.java
@@ -2,9 +2,11 @@ package com.goo.bikerelocationproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class BikeRelocationProjectApplication {
 

--- a/src/main/java/com/goo/bikerelocationproject/config/CorsMvcConfig.java
+++ b/src/main/java/com/goo/bikerelocationproject/config/CorsMvcConfig.java
@@ -1,0 +1,14 @@
+package com.goo.bikerelocationproject.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**").allowedOrigins("http://localhost:3000");
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/config/SecurityConfig.java
+++ b/src/main/java/com/goo/bikerelocationproject/config/SecurityConfig.java
@@ -1,0 +1,87 @@
+package com.goo.bikerelocationproject.config;
+
+import com.goo.bikerelocationproject.jwt.JwtFilter;
+import com.goo.bikerelocationproject.jwt.JwtUtil;
+import com.goo.bikerelocationproject.jwt.LoginFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final AuthenticationConfiguration authenticationConfiguration;
+  private final JwtUtil jwtUtil;
+
+  @Bean
+  public BCryptPasswordEncoder bCryptPasswordEncoder() {
+
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+
+    return configuration.getAuthenticationManager();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+        .csrf((auth) -> auth.disable())
+        .formLogin((auth) -> auth.disable())
+        .httpBasic((auth) -> auth.disable());
+
+    http
+        .cors((cors) -> cors
+            .configurationSource(new CorsConfigurationSource() {
+              @Override
+              public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                CorsConfiguration corsConfiguration = new CorsConfiguration();
+                corsConfiguration.setAllowedOrigins(
+                    Collections.singletonList("http://localhost:3000"));
+                corsConfiguration.setAllowedMethods(Collections.singletonList("*"));
+                corsConfiguration.setAllowCredentials(true);
+                corsConfiguration.setAllowedHeaders(Collections.singletonList("*"));
+                corsConfiguration.setMaxAge(3600L);
+                corsConfiguration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                return corsConfiguration;
+              }
+            }));
+
+    http
+        .authorizeHttpRequests((auth) -> auth
+            .requestMatchers("/", "/api/open-api-station", "/api/open-api-parking").permitAll()
+            .requestMatchers("/auth/**").permitAll()
+            .requestMatchers("/api/station/**").hasRole("USER")
+            .anyRequest().authenticated());
+
+    http
+        .sessionManagement((session) -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .addFilterAfter(
+            new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil),
+            LogoutFilter.class)
+        .addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/controller/AuthController.java
+++ b/src/main/java/com/goo/bikerelocationproject/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.goo.bikerelocationproject.controller;
+
+import com.goo.bikerelocationproject.data.dto.auth.JoinDto;
+import com.goo.bikerelocationproject.data.dto.auth.UserInfoDto;
+import com.goo.bikerelocationproject.service.impl.AuthServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+  private final AuthServiceImpl authService;
+  private final Logger LOGGER = LoggerFactory.getLogger(AuthController.class);
+
+  @PostMapping("/join")
+  public ResponseEntity<UserInfoDto> join(@RequestBody JoinDto joinDto) {
+
+    LOGGER.info("[join]: {}", joinDto.toString());
+
+    UserInfoDto userInfo = authService.join(joinDto);
+
+    return ResponseEntity.ok(userInfo);
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/auth/CustomUserDetails.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/auth/CustomUserDetails.java
@@ -1,0 +1,63 @@
+package com.goo.bikerelocationproject.data.dto.auth;
+
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+  private final CustomUser user;
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+
+    Collection<GrantedAuthority> collection = new ArrayList<>();
+
+    collection.add(new GrantedAuthority() {
+      @Override
+      public String getAuthority() {
+        return user.getRole();
+      }
+    });
+
+    return collection;
+  }
+
+  @Override
+  public String getPassword() {
+    return user.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getUsername();
+  }
+
+  public String getEmail() {
+    return user.getEmail();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/auth/JoinDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/auth/JoinDto.java
@@ -1,0 +1,27 @@
+package com.goo.bikerelocationproject.data.dto.auth;
+
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import com.goo.bikerelocationproject.type.Roles;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter
+@Getter
+@Builder
+@ToString
+public class JoinDto {
+
+  private String username;
+  private String email;
+  private String password;
+
+  public static CustomUser toEntity(JoinDto joinDto) {
+    return CustomUser.builder()
+        .username(joinDto.getUsername())
+        .email(joinDto.getEmail())
+        .role(Roles.USER.getRole())
+        .build();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/dto/auth/UserInfoDto.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/dto/auth/UserInfoDto.java
@@ -1,0 +1,31 @@
+package com.goo.bikerelocationproject.data.dto.auth;
+
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Setter
+@Getter
+@Builder
+@ToString
+public class UserInfoDto {
+
+  private Long id;
+  private String username;
+  private String password;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static UserInfoDto fromEntity(CustomUser user) {
+    return UserInfoDto.builder()
+        .id(user.getId())
+        .username(user.getUsername())
+        .password(user.getPassword())
+        .createdAt(user.getCreatedAt())
+        .updatedAt(user.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/entity/BaseEntity.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.goo.bikerelocationproject.data.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/goo/bikerelocationproject/data/entity/CustomUser.java
+++ b/src/main/java/com/goo/bikerelocationproject/data/entity/CustomUser.java
@@ -1,0 +1,38 @@
+package com.goo.bikerelocationproject.data.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@ToString
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class CustomUser extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String username;
+
+  @Column(nullable = false, unique = true)
+  private String email;
+
+  @Column(nullable = false)
+  private String password;
+
+  private String role;
+}

--- a/src/main/java/com/goo/bikerelocationproject/jwt/JwtFilter.java
+++ b/src/main/java/com/goo/bikerelocationproject/jwt/JwtFilter.java
@@ -1,0 +1,53 @@
+package com.goo.bikerelocationproject.jwt;
+
+import com.goo.bikerelocationproject.data.dto.auth.CustomUserDetails;
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+  private final JwtUtil jwtUtil;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String authorization = request.getHeader(TOKEN_HEADER);
+    if (authorization == null || !authorization.startsWith(TOKEN_PREFIX)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String token = authorization.split(" ")[1];
+    if (jwtUtil.isExpired(token)) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    CustomUser user = CustomUser.builder()
+        .username(jwtUtil.getUsername(token))
+        .role(jwtUtil.getRole(token))
+        .password("tempPassword")
+        .build();
+
+    CustomUserDetails userDetails = new CustomUserDetails(user);
+    Authentication authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null,
+        userDetails.getAuthorities());
+
+    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/jwt/JwtUtil.java
+++ b/src/main/java/com/goo/bikerelocationproject/jwt/JwtUtil.java
@@ -1,0 +1,47 @@
+package com.goo.bikerelocationproject.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+  private final SecretKey secretKey;
+
+  public JwtUtil(@Value("${jwt-secret-key}") String secretKey) {
+    this.secretKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
+        SIG.HS256.key().build().getAlgorithm());
+  }
+
+  public String getUsername(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("username", String.class);
+  }
+
+  public String getRole(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("role", String.class);
+  }
+
+  public boolean isExpired(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .getExpiration().before(new Date());
+  }
+
+  public String createJwt(String username, String role, Long expiredMs) {
+
+    return Jwts.builder()
+        .claim("username", username)
+        .claim("role", role)
+        .issuedAt(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + expiredMs))
+        .signWith(secretKey)
+        .compact();
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/jwt/LoginFilter.java
+++ b/src/main/java/com/goo/bikerelocationproject/jwt/LoginFilter.java
@@ -1,0 +1,83 @@
+package com.goo.bikerelocationproject.jwt;
+
+import com.goo.bikerelocationproject.data.dto.auth.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Iterator;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+public class LoginFilter extends AbstractAuthenticationProcessingFilter {
+
+  private static final String SPRING_SECURITY_FORM_EMAIL_KEY = "email";
+  private static final String SPRING_SECURITY_FORM_PASSWORD_KEY = "password";
+  private static final String LOGIN_REQUEST_URL = "/auth/login";
+  private static final String HTTP_METHOD = "POST";
+  private static final AntPathRequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER =
+      new AntPathRequestMatcher(LOGIN_REQUEST_URL, HTTP_METHOD);
+
+  public static final String TOKEN_HEADER = "Authorization";
+  public static final String TOKEN_PREFIX = "Bearer ";
+
+  private final JwtUtil jwtUtil;
+  private final AuthenticationManager authenticationManager;
+
+  public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+    super(DEFAULT_ANT_PATH_REQUEST_MATCHER);
+    this.authenticationManager = authenticationManager;
+    this.jwtUtil = jwtUtil;
+
+  }
+
+  @Override
+  public Authentication attemptAuthentication(HttpServletRequest request,
+      HttpServletResponse response) throws AuthenticationException {
+
+    String email = obtainEmail(request);
+    String password = obtainPassword(request);
+    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+        email, password, null);
+
+    return authenticationManager.authenticate(authToken);
+  }
+
+  protected String obtainEmail(HttpServletRequest request) {
+    return request.getParameter(SPRING_SECURITY_FORM_EMAIL_KEY);
+  }
+
+  protected String obtainPassword(HttpServletRequest request) {
+    return request.getParameter(SPRING_SECURITY_FORM_PASSWORD_KEY);
+  }
+
+  @Override
+  protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
+      FilterChain chain, Authentication authResult) {
+
+    CustomUserDetails userDetails = (CustomUserDetails) authResult.getPrincipal();
+    String email = userDetails.getEmail();
+
+    Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+    Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+    GrantedAuthority auth = iterator.next();
+
+    String role = auth.getAuthority();
+    String token = jwtUtil.createJwt(email, role, Duration.ofMinutes(10).toMillis());
+
+    response.addHeader(TOKEN_HEADER, TOKEN_PREFIX + token);
+  }
+
+  @Override
+  protected void unsuccessfulAuthentication(HttpServletRequest request,
+      HttpServletResponse response, AuthenticationException failed) {
+
+    response.setStatus(401);
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/repository/UserRepo.java
+++ b/src/main/java/com/goo/bikerelocationproject/repository/UserRepo.java
@@ -1,0 +1,12 @@
+package com.goo.bikerelocationproject.repository;
+
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepo extends JpaRepository<CustomUser, Long> {
+
+  Optional<CustomUser> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/AuthService.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/AuthService.java
@@ -1,0 +1,9 @@
+package com.goo.bikerelocationproject.service;
+
+import com.goo.bikerelocationproject.data.dto.auth.JoinDto;
+import com.goo.bikerelocationproject.data.dto.auth.UserInfoDto;
+
+public interface AuthService {
+
+  UserInfoDto join(JoinDto joinDto);
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/impl/AuthServiceImpl.java
@@ -1,0 +1,33 @@
+package com.goo.bikerelocationproject.service.impl;
+
+import static com.goo.bikerelocationproject.type.ErrorCode.ALREADY_EXIST_USERNAME;
+
+import com.goo.bikerelocationproject.data.dto.auth.JoinDto;
+import com.goo.bikerelocationproject.data.dto.auth.UserInfoDto;
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import com.goo.bikerelocationproject.exception.StationException;
+import com.goo.bikerelocationproject.repository.UserRepo;
+import com.goo.bikerelocationproject.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+  private final UserRepo userRepo;
+  private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+  @Override
+  public UserInfoDto join(JoinDto joinDto) {
+    if (userRepo.existsByEmail(joinDto.getEmail())) {
+      throw new StationException(ALREADY_EXIST_USERNAME);
+    }
+
+    CustomUser user = JoinDto.toEntity(joinDto);
+    user.setPassword(bCryptPasswordEncoder.encode(joinDto.getPassword()));
+
+    return UserInfoDto.fromEntity(userRepo.save(user));
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/service/impl/UserDetailsServiceImpl.java
+++ b/src/main/java/com/goo/bikerelocationproject/service/impl/UserDetailsServiceImpl.java
@@ -1,0 +1,29 @@
+package com.goo.bikerelocationproject.service.impl;
+
+import static com.goo.bikerelocationproject.type.ErrorCode.NOT_FOUND_USER;
+
+import com.goo.bikerelocationproject.data.dto.auth.CustomUserDetails;
+import com.goo.bikerelocationproject.data.entity.CustomUser;
+import com.goo.bikerelocationproject.exception.StationException;
+import com.goo.bikerelocationproject.repository.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+  private final UserRepo userRepo;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+    CustomUser user = userRepo.findByEmail(email)
+        .orElseThrow(() -> new StationException(NOT_FOUND_USER));
+
+    return new CustomUserDetails(user);
+  }
+}

--- a/src/main/java/com/goo/bikerelocationproject/type/ErrorCode.java
+++ b/src/main/java/com/goo/bikerelocationproject/type/ErrorCode.java
@@ -9,7 +9,9 @@ public enum ErrorCode {
 
   OPEN_API_ERROR("open-api: 데이터 저장에 실패했습니다."),
   REDIS_NULL("redis 에서 값을 불러오지 못했습니다."),
-  NOT_FOUND_STATION("대여소 정보가 존재하지 않습니다.");
+  NOT_FOUND_STATION("대여소 정보가 존재하지 않습니다."),
+  NOT_FOUND_USER("유저 정보가 존재하지 않습니다."),
+  ALREADY_EXIST_USERNAME("이미 존재하는 아이디입니다.");
 
   private final String description;
 }

--- a/src/main/java/com/goo/bikerelocationproject/type/Roles.java
+++ b/src/main/java/com/goo/bikerelocationproject/type/Roles.java
@@ -1,0 +1,13 @@
+package com.goo.bikerelocationproject.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Roles {
+
+  USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+
+  private final String role;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
     generate-ddl: true
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
   profiles:
-    include: api-key
+    include: api-key, jwt-key, oauth


### PR DESCRIPTION
### 변경사항

**AS-IS**

**TO-BE**
- jwt 와 시큐리티를 이용한 이메일 로그인 구현 (jwt : 0.12.3)
  - `로그인 성공 시 토큰 반환` / `실패 시 401 에러` 로 처리했습니다.
  -  리스트 전체 정보와 세부정보를 불러올 때 토큰이 필요합니다.
- 이메일 로그인을 구현하기 위해 usernamePasswordAuthenticationFilter 를 참고하여 커스텀했습니다.

### 테스트

- [x] 테스트 코드
- [x] API 테스트 